### PR TITLE
Fix missing additional params on bulk person retrieve

### DIFF
--- a/model/person.go
+++ b/model/person.go
@@ -123,6 +123,7 @@ type RetrievePersonResponse struct {
 type BulkRetrievePersonParams struct {
 	BaseParams
 	Requests []BulkRetrieveSinglePersonParams `json:"requests"`
+	AdditionalParams
 }
 
 func (params BulkRetrievePersonParams) Validate() error {


### PR DESCRIPTION
## Description of the change

[Bulk Person Retrieve](https://docs.peopledatalabs.com/docs/bulk-person-retrieve) endpoint allows clients to provide `titlecase` param. The library did not.
This PR adds the `AdditionalParams` struct to the `BulkPersonRetrieveParams` struct making it compliant with the expected behaviour

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
