### PR TITLE
Removed methods allowing to provide no context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.0.1] - 2022-06-19
 - Incremented default timeout from 5 seconds to 10 seconds
 - Added `AdditionalParams` to Bulk Person Retrieve params
- 
+
+## [1.1.0] - 2022-06-25
+- Removed methods that allow no context to be provided
+- Removed commented parameters on Company Cleaner endpoint

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ params := pdlmodel.EnrichPersonParams{
     },
 }
 
-result, err := client.Person.Enrich(params)
+result, err := client.Person.Enrich(ctx, params)
 
 if err == nil {
     fmt.Printf("Status: %d, FullName: %s\n", result.Status, result.Data.FullName)
@@ -96,7 +96,7 @@ params := pdlmodel.BulkEnrichPersonParams{
     },
 }
 
-result, err := client.Person.BulkEnrich(params)
+result, err := client.Person.BulkEnrich(ctx, params)
 ```
 
 #### Search (Elasticsearch)
@@ -122,7 +122,7 @@ params := pdlmodel.SearchParams{
         Dataset: "phone,mobile_phone",
     },
 }
-result, err := client.Person.Search(params)
+result, err := client.Person.Search(ctx, params)
 ```
 
 #### Search (SQL)
@@ -142,7 +142,7 @@ params := pdlmodel.SearchParams{
         Dataset: "phone,mobile_phone",
     },
 }
-result, err := client.Person.Search(params)
+result, err := client.Person.Search(ctx, params)
 ```
 
 #### `PDL_ID` (Retrieve API)
@@ -150,7 +150,7 @@ result, err := client.Person.Search(params)
 ```go
 params := pdlmodel.RetrievePersonParams{PersonID: "qEnOZ5Oh0poWnQ1luFBfVw_0000"}
 
-result, err := client.Person.Retrieve(params)
+result, err := client.Person.Retrieve(ctx, params)
 ```
 
 #### Bulk Retrieve API
@@ -163,7 +163,7 @@ params := pdlmodel.BulkRetrievePersonParams{
     }
 }
 
-result, err := client.Person.BulkRetrieve(params)
+result, err := client.Person.BulkRetrieve(ctx, params)
 ```
 
 #### Fuzzy Enrichment (Identify API)
@@ -171,7 +171,7 @@ result, err := client.Person.BulkRetrieve(params)
 ```go
 params := pdlmodel.IdentifyPersonParams{PersonParams: pdlmodel.PersonParams{Name: []string{"sean thorne"}}}
 
-result, err := client.Person.Identify(params)
+result, err := client.Person.Identify(ctx, params)
 ```
 
 ### Company Data
@@ -183,7 +183,7 @@ params := pdlmodel.EnrichCompanyParams{
     CompanyParams: pdlmodel.CompanyParams{Website: "peopledatalabs.com"},
 }
 
-result, err := client.Company.Enrich(params)
+result, err := client.Company.Enrich(ctx, params)
 ```
 
 #### Search (Elasticsearch)
@@ -206,7 +206,7 @@ params := pdlmodel.SearchParams{
     SearchBaseParams: pdlmodel.SearchBaseParams{Query: elasticSearchQuery},
 }
 
-result, err := client.Company.Search(params)
+result, err := client.Company.Search(ctx, params)
 ```
 
 #### Search (SQL)
@@ -222,7 +222,7 @@ params := pdlmodel.SearchParams{
     SearchBaseParams: pdlmodel.SearchBaseParams{SQL: sqlQuery},
 }
 
-result, err := client.Company.Search(params)
+result, err := client.Company.Search(ctx, params)
 
 ```
 
@@ -236,7 +236,7 @@ params := pdlmodel.AutocompleteParams{
     AutocompleteBaseParams: pdlmodel.AutocompleteBaseParams{Field: "title", Text: "full"},
 }
 
-result, err := client.Autocomplete(params)
+result, err := client.Autocomplete(ctx, params)
 ```
 
 #### Clean Raw Company Strings
@@ -244,7 +244,7 @@ result, err := client.Autocomplete(params)
 ```go
 params := pdlmodel.CleanCompanyParams{Name: "peOple DaTa LabS"}
 
-result, err := client.Company.Clean(params)
+result, err := client.Company.Clean(ctx, params)
 ```
 
 #### Clean Raw Location Strings
@@ -256,7 +256,7 @@ params := pdlmodel.CleanLocationParams{
     },
 }
 
-result, err := client.Location.Clean(params)
+result, err := client.Location.Clean(ctx, params)
 ```
 
 #### Clean Raw School Strings
@@ -266,7 +266,7 @@ params := pdlmodel.CleanSchoolParams{
     SchoolParams: pdlmodel.SchoolParams{Name: "university of oregon"},
 }
 
-result, err := client.School.Clean(params)
+result, err := client.School.Clean(ctx, params)
 ```
 
 ## 🌐 Endpoints <a name="endpoints"></a>
@@ -297,9 +297,6 @@ result, err := client.School.Clean(params)
 | [Company Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#companyclean)   | `client.Company.Clean(params)`  |
 | [Location Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#locationclean) | `client.Location.Clean(params)` |
 | [School Cleaner API](https://docs.peopledatalabs.com/docs/cleaner-apis#schoolclean)     | `client.School.Clean(params)`   |
-
-Each method has it's own _WithContext(...)_ version where you can provide your own `context.Context`
-For example: `client.Person.Identify(params)` => `client.Person.IdentifyWithContext(ctx, params)`
 
 ## 📘 Documentation <a name="documentation"></a>
 

--- a/internal/api/autocomplete.go
+++ b/internal/api/autocomplete.go
@@ -14,16 +14,12 @@ type Autocomplete struct {
 	Client
 }
 
-type AutocompleteFunc func(params model.AutocompleteParams) (model.AutocompleteResponse, error)
-type AutocompleteWitchContextFunc func(ctx context.Context, params model.AutocompleteParams) (model.AutocompleteResponse, error)
+type AutocompleteFunc func(ctx context.Context, params model.AutocompleteParams) (model.AutocompleteResponse, error)
 
 // Autocomplete allows your users to get suggestions for Search API query values
 // along with the number of available records for each suggestion.
 // For example, schools starting with "stanf".
-func (a Autocomplete) Autocomplete(params model.AutocompleteParams) (model.AutocompleteResponse, error) {
-	return a.AutocompleteWithContext(context.Background(), params)
-}
-func (a Autocomplete) AutocompleteWithContext(ctx context.Context, params model.AutocompleteParams) (model.AutocompleteResponse, error) {
+func (a Autocomplete) Autocomplete(ctx context.Context, params model.AutocompleteParams) (model.AutocompleteResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.AutocompleteResponse{}, err
 	}

--- a/internal/api/autocomplete_test.go
+++ b/internal/api/autocomplete_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -19,7 +20,7 @@ func TestAutocomplete(t *testing.T) {
 		BaseParams:             model.BaseParams{Pretty: true, Size: 10},
 		AutocompleteBaseParams: model.AutocompleteBaseParams{Field: "school", Text: "stanf"},
 	}
-	resp, err := auto.Autocomplete(params)
+	resp, err := auto.Autocomplete(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)

--- a/internal/api/company.go
+++ b/internal/api/company.go
@@ -18,10 +18,7 @@ type Company struct {
 
 // Enrich a company
 // docs: https://docs.peopledatalabs.com/docs/company-enrichment-api
-func (c Company) Enrich(params model.EnrichCompanyParams) (model.EnrichCompanyResponse, error) {
-	return c.EnrichWithContext(context.Background(), params)
-}
-func (c Company) EnrichWithContext(ctx context.Context, params model.EnrichCompanyParams) (model.EnrichCompanyResponse, error) {
+func (c Company) Enrich(ctx context.Context, params model.EnrichCompanyParams) (model.EnrichCompanyResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.EnrichCompanyResponse{}, err
 	}
@@ -32,10 +29,7 @@ func (c Company) EnrichWithContext(ctx context.Context, params model.EnrichCompa
 // Search gives you access to every record in our full Company dataset,
 // which you can filter and segment using a search query.
 // docs: https://docs.peopledatalabs.com/docs/company-search-api
-func (c Company) Search(params model.SearchParams) (model.SearchCompanyResponse, error) {
-	return c.SearchWithContext(context.Background(), params)
-}
-func (c Company) SearchWithContext(ctx context.Context, params model.SearchParams) (model.SearchCompanyResponse, error) {
+func (c Company) Search(ctx context.Context, params model.SearchParams) (model.SearchCompanyResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.SearchCompanyResponse{}, err
 	}
@@ -45,10 +39,7 @@ func (c Company) SearchWithContext(ctx context.Context, params model.SearchParam
 
 // Clean your company data, so you can better query our person data
 // docs: https://docs.peopledatalabs.com/docs/cleaner-apis-reference#company-cleaner-api-companyclean-1
-func (c Company) Clean(params model.CleanCompanyParams) (model.CleanCompanyResponse, error) {
-	return c.CleanWithContext(context.Background(), params)
-}
-func (c Company) CleanWithContext(ctx context.Context, params model.CleanCompanyParams) (model.CleanCompanyResponse, error) {
+func (c Company) Clean(ctx context.Context, params model.CleanCompanyParams) (model.CleanCompanyResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.CleanCompanyResponse{}, err
 	}

--- a/internal/api/company_test.go
+++ b/internal/api/company_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -18,7 +19,7 @@ func TestCompany_Enrich(t *testing.T) {
 	params := model.EnrichCompanyParams{
 		CompanyParams: model.CompanyParams{Name: "Google, Inc."},
 	}
-	resp, err := company.Enrich(params)
+	resp, err := company.Enrich(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -32,7 +33,7 @@ func TestCompany_Clean(t *testing.T) {
 
 	// test
 	params := model.CleanCompanyParams{Website: "apple.com"}
-	resp, err := company.Clean(params)
+	resp, err := company.Clean(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -48,7 +49,7 @@ func TestCompany_Search(t *testing.T) {
 		BaseParams:       model.BaseParams{Size: 100},
 		SearchBaseParams: model.SearchBaseParams{SQL: "SELECT * FROM company WHERE name='people data labs'"},
 	}
-	resp, err := company.Search(params)
+	resp, err := company.Search(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)

--- a/internal/api/location.go
+++ b/internal/api/location.go
@@ -14,10 +14,7 @@ type Location struct {
 
 // Clean your location data, so you can better query our person data
 // docs: https://docs.peopledatalabs.com/docs/cleaner-apis-reference#location-cleaner-api-locationclean
-func (l Location) Clean(params model.CleanLocationParams) (model.CleanLocationResponse, error) {
-	return l.CleanWithContext(context.Background(), params)
-}
-func (l Location) CleanWithContext(ctx context.Context, params model.CleanLocationParams) (model.CleanLocationResponse, error) {
+func (l Location) Clean(ctx context.Context, params model.CleanLocationParams) (model.CleanLocationResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.CleanLocationResponse{}, err
 	}

--- a/internal/api/location_test.go
+++ b/internal/api/location_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -18,7 +19,7 @@ func TestLocation_Clean(t *testing.T) {
 	params := model.CleanLocationParams{
 		LocationParams: model.LocationParams{Location: "portland"},
 	}
-	resp, err := location.Clean(params)
+	resp, err := location.Clean(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)

--- a/internal/api/person.go
+++ b/internal/api/person.go
@@ -22,10 +22,7 @@ type Person struct {
 
 // Enrich a person record on a variety of fields
 // docs: https://docs.peopledatalabs.com/docs/reference-person-enrichment-api
-func (p Person) Enrich(params model.EnrichPersonParams) (model.EnrichPersonResponse, error) {
-	return p.EnrichWithContext(context.Background(), params)
-}
-func (p Person) EnrichWithContext(ctx context.Context, params model.EnrichPersonParams) (model.EnrichPersonResponse, error) {
+func (p Person) Enrich(ctx context.Context, params model.EnrichPersonParams) (model.EnrichPersonResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.EnrichPersonResponse{}, err
 	}
@@ -35,10 +32,7 @@ func (p Person) EnrichWithContext(ctx context.Context, params model.EnrichPerson
 
 // BulkEnrich allows to enrich up to 100 persons in a single HTTP request
 // docs: https://docs.peopledatalabs.com/docs/bulk-enrichment-api
-func (p Person) BulkEnrich(params model.BulkEnrichPersonParams) ([]model.BulkEnrichPersonResponse, error) {
-	return p.BulkEnrichWithContext(context.Background(), params)
-}
-func (p Person) BulkEnrichWithContext(ctx context.Context, params model.BulkEnrichPersonParams) ([]model.BulkEnrichPersonResponse, error) {
+func (p Person) BulkEnrich(ctx context.Context, params model.BulkEnrichPersonParams) ([]model.BulkEnrichPersonResponse, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}
@@ -48,10 +42,7 @@ func (p Person) BulkEnrichWithContext(ctx context.Context, params model.BulkEnri
 
 // Identify recovers all related profiles for an identity
 // docs: https://docs.peopledatalabs.com/docs/identify-api
-func (p Person) Identify(params model.IdentifyPersonParams) (model.IdentifyPersonResponse, error) {
-	return p.IdentifyWithContext(context.Background(), params)
-}
-func (p Person) IdentifyWithContext(ctx context.Context, params model.IdentifyPersonParams) (model.IdentifyPersonResponse, error) {
+func (p Person) Identify(ctx context.Context, params model.IdentifyPersonParams) (model.IdentifyPersonResponse, error) {
 	var response model.IdentifyPersonResponse
 	return response, p.Client.get(ctx, personIdentifyPath, params, &response)
 }
@@ -59,10 +50,7 @@ func (p Person) IdentifyWithContext(ctx context.Context, params model.IdentifyPe
 // Search is perfect for finding specific segments of people that you need to power your projects and products.
 // It gives you direct access to our full API dataset.
 // docs: https://docs.peopledatalabs.com/docs/person-search-api
-func (p Person) Search(params model.SearchParams) (model.SearchPersonResponse, error) {
-	return p.SearchWithContext(context.Background(), params)
-}
-func (p Person) SearchWithContext(ctx context.Context, params model.SearchParams) (model.SearchPersonResponse, error) {
+func (p Person) Search(ctx context.Context, params model.SearchParams) (model.SearchPersonResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.SearchPersonResponse{}, err
 	}
@@ -72,10 +60,7 @@ func (p Person) SearchWithContext(ctx context.Context, params model.SearchParams
 
 // Retrieve allows you to use a PDL Person ID to return data associated with that ID
 // docs: https://docs.peopledatalabs.com/docs/person-retrieve-api
-func (p Person) Retrieve(params model.RetrievePersonParams) (model.RetrievePersonResponse, error) {
-	return p.RetrieveWithContext(context.Background(), params)
-}
-func (p Person) RetrieveWithContext(ctx context.Context, params model.RetrievePersonParams) (model.RetrievePersonResponse, error) {
+func (p Person) Retrieve(ctx context.Context, params model.RetrievePersonParams) (model.RetrievePersonResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.RetrievePersonResponse{}, err
 	}
@@ -86,10 +71,7 @@ func (p Person) RetrieveWithContext(ctx context.Context, params model.RetrievePe
 
 // BulkRetrieve allows to retrieve up to 100 persons in a single HTTP request
 // docs: https://docs.peopledatalabs.com/docs/bulk-person-retrieve
-func (p Person) BulkRetrieve(params model.BulkRetrievePersonParams) ([]model.BulkRetrievePersonResponse, error) {
-	return p.BulkRetrieveWithContext(context.Background(), params)
-}
-func (p Person) BulkRetrieveWithContext(ctx context.Context, params model.BulkRetrievePersonParams) ([]model.BulkRetrievePersonResponse, error) {
+func (p Person) BulkRetrieve(ctx context.Context, params model.BulkRetrievePersonParams) ([]model.BulkRetrievePersonResponse, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}

--- a/internal/api/person_test.go
+++ b/internal/api/person_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -19,7 +20,7 @@ func TestPerson_Enrich(t *testing.T) {
 		PersonParams:     model.PersonParams{Profile: []string{"http://linkedin.com/in/seanthorne"}},
 		AdditionalParams: model.AdditionalParams{MinLikelihood: 6},
 	}
-	resp, err := person.Enrich(params)
+	resp, err := person.Enrich(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -40,7 +41,7 @@ func TestPerson_Identify(t *testing.T) {
 			Company:   []string{"people data labs"},
 		},
 	}
-	resp, err := person.Identify(params)
+	resp, err := person.Identify(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -62,7 +63,7 @@ func TestPerson_Search(t *testing.T) {
 			SQL: "SELECT * FROM person WHERE location_country='mexico' AND job_title_role='health' AND phone_numbers IS NOT NULL;",
 		},
 	}
-	resp, err := person.Search(params)
+	resp, err := person.Search(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -78,7 +79,7 @@ func TestPerson_Retrieve(t *testing.T) {
 
 	// test
 	params := model.RetrievePersonParams{PersonID: id}
-	resp, err := person.Retrieve(params)
+	resp, err := person.Retrieve(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)
@@ -100,7 +101,7 @@ func TestPerson_BulkRetrieve(t *testing.T) {
 			{ID: id2},
 		},
 	}
-	resp, err := person.BulkRetrieve(params)
+	resp, err := person.BulkRetrieve(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)

--- a/internal/api/school.go
+++ b/internal/api/school.go
@@ -14,10 +14,7 @@ type School struct {
 
 // Clean your school data, so you can better query our person data
 // docs: https://docs.peopledatalabs.com/docs/cleaner-apis-reference#school-cleaner-api-schoolclean
-func (s School) Clean(params model.CleanSchoolParams) (model.CleanSchoolResponse, error) {
-	return s.CleanWithContext(context.Background(), params)
-}
-func (s School) CleanWithContext(ctx context.Context, params model.CleanSchoolParams) (model.CleanSchoolResponse, error) {
+func (s School) Clean(ctx context.Context, params model.CleanSchoolParams) (model.CleanSchoolResponse, error) {
 	if err := params.Validate(); err != nil {
 		return model.CleanSchoolResponse{}, err
 	}

--- a/internal/api/school_test.go
+++ b/internal/api/school_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -18,7 +19,7 @@ func TestSchool_Clean(t *testing.T) {
 	params := model.CleanSchoolParams{
 		SchoolParams: model.SchoolParams{Profile: "linkedin.com/school/ucla"},
 	}
-	resp, err := school.Clean(params)
+	resp, err := school.Clean(context.Background(), params)
 
 	// assertions
 	assert.NoError(t, err)

--- a/model/company.go
+++ b/model/company.go
@@ -35,22 +35,9 @@ type EnrichCompanyResponse struct {
 }
 
 type CleanCompanyParams struct {
-	BaseParams
 	Name    string `json:"name,omitempty" url:"name,omitempty"`       // The name of the company
 	Website string `json:"website,omitempty" url:"website,omitempty"` // A website the company uses
 	Profile string `json:"profile,omitempty" url:"profile,omitempty"` // A social profile of the company (linkedin/facebook/twitter/crunchbase)
-
-	//Ticker        string   `json:"ticker,omitempty" url:"ticker,omitempty"`                 // Company stock ticker
-	//Location      []string `json:"location,omitempty" url:"location,omitempty"`             // Complete or partial company location
-	//Locality      string   `json:"locality,omitempty" url:"locality,omitempty"`             //	Company locality
-	//Region        string   `json:"region,omitempty" url:"region,omitempty"`                 //	Company region
-	//Country       string   `json:"country,omitempty" url:"country,omitempty"`               //	Company country
-	//Address string   `json:"street_address,omitempty" url:"street_address,omitempty"` //	Company address
-	//PostalCode    string   `json:"postal_code,omitempty" url:"postal_code,omitempty"`       //	Company postal code
-
-	// TODO: Check if we can use AdditionalParams (missing DataInclude, MinLikelihood, Required, IncludeIfMatched)
-	// TODO: Check if we can use TitleCase
-	//TitleCase        bool   `json:"titlecase" url:"titlecase,omitempty"`                   // Setting titlecase to true will titlecase the response data in 200 responses.
 }
 
 func (params CleanCompanyParams) Validate() error {

--- a/pld.go
+++ b/pld.go
@@ -4,7 +4,7 @@ import (
 	"github.com/peopledatalabs/peopledatalabs-go/internal/api"
 )
 
-const Version = "1.0.1"
+const Version = "1.1.0"
 
 type pld struct {
 	Person       api.Person

--- a/pld.go
+++ b/pld.go
@@ -7,12 +7,11 @@ import (
 const Version = "1.0.1"
 
 type pld struct {
-	Person                  api.Person
-	Company                 api.Company
-	Location                api.Location
-	School                  api.School
-	Autocomplete            api.AutocompleteFunc
-	AutocompleteWithContext api.AutocompleteWitchContextFunc
+	Person       api.Person
+	Company      api.Company
+	Location     api.Location
+	School       api.School
+	Autocomplete api.AutocompleteFunc
 }
 
 // New returns a new People Data Labs Client
@@ -25,11 +24,10 @@ func New(apiKey string, opts ...api.ClientOptions) *pld {
 
 	autocompleteClient := api.Autocomplete{Client: client}
 	return &pld{
-		Person:                  api.Person{Client: client},
-		Company:                 api.Company{Client: client},
-		Location:                api.Location{Client: client},
-		School:                  api.School{Client: client},
-		Autocomplete:            autocompleteClient.Autocomplete,
-		AutocompleteWithContext: autocompleteClient.AutocompleteWithContext,
+		Person:       api.Person{Client: client},
+		Company:      api.Company{Client: client},
+		Location:     api.Location{Client: client},
+		School:       api.School{Client: client},
+		Autocomplete: autocompleteClient.Autocomplete,
 	}
 }


### PR DESCRIPTION
## Description of the change

Removed al methods that allow no context to be provided.

_Example:_ 
Before: 
+ `EnrichPerson(params)`
+ `EnrichPersonWithContext(context, params)`
Now:
+ `EnrichPerson(context, params)`


Also, removed commented parameters on Company Cleaner API.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
