### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,4 @@
 name: Test
-permissions:
-  contents: read
 on:
   push:
     branches: [ main ]
@@ -9,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Fix for [https://github.com/peopledatalabs/peopledatalabs-go/security/code-scanning/1](https://github.com/peopledatalabs/peopledatalabs-go/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the code and runs tests, it only needs `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.