### PR TITLE
Bump version to 6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added employee_growth_rate_12_month_by_country to Company Schema (PDL API v33.2)
 - Field is a map of country code to struct with current_headcount, 12_month_headcount, and 12_month_growth_rate
+
+## [6.7.0] - 2026-07-22
+
+- Added technologies_used to Company Schema (PDL API v35.0)
+- RestError.Details.Type now accepts either a string or an array of strings from the API

--- a/pld.go
+++ b/pld.go
@@ -4,7 +4,7 @@ import (
 	"github.com/peopledatalabs/peopledatalabs-go/v6/api"
 )
 
-const Version = "6.5.0"
+const Version = "6.7.0"
 
 type pld struct {
 	Person       api.Person


### PR DESCRIPTION
## Summary
- Adds CHANGELOG entry for PDL API v35.0 support (technologies_used on Company, tolerant error.type parsing)
- Bumps Version constant in pld.go to 6.7.0

## Test plan
- [x] go build ./...
- [x] go vet ./...